### PR TITLE
Fix getting progress when there are no strings

### DIFF
--- a/wagtail_localize/models.py
+++ b/wagtail_localize/models.py
@@ -23,6 +23,7 @@ from django.db.models import (
     Value,
     When,
 )
+from django.db.models.functions import Coalesce
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.urls import reverse
@@ -1139,7 +1140,8 @@ class Translation(models.Model):
                 output_field=IntegerField(),
             )
         ).aggregate(
-            total_segments=Count("pk"), translated_segments=Sum("is_translated_i")
+            total_segments=Count("pk"),
+            translated_segments=Coalesce(Sum("is_translated_i"), 0),
         )
 
         return aggs["total_segments"], aggs["translated_segments"]

--- a/wagtail_localize/tests/test_translation_model.py
+++ b/wagtail_localize/tests/test_translation_model.py
@@ -155,6 +155,18 @@ class TestGetProgress(TestCase):
         progress = self.translation.get_progress()
         self.assertEqual(progress, (2, 0))
 
+    def test_get_progress_with_no_strings(self):
+        # Check getting progress when there are no strings to be translated
+        page = create_test_page(title="Empty page", slug="empty-page")
+        source, created = TranslationSource.get_or_create_from_instance(page)
+        translation = Translation.objects.create(
+            source=source,
+            target_locale=self.fr_locale,
+        )
+
+        progress = translation.get_progress()
+        self.assertEqual(progress, (0, 0))
+
 
 class TestExportPO(TestCase):
     def setUp(self):
@@ -576,6 +588,17 @@ class TestGetStatus(TestCase):
         )
 
         self.assertEqual(self.translation.get_status_display(), "Up to date")
+
+    def test_get_status_with_no_strings(self):
+        # Check getting status when there are no strings to be translated
+        page = create_test_page(title="Empty page", slug="empty-page")
+        source, created = TranslationSource.get_or_create_from_instance(page)
+        translation = Translation.objects.create(
+            source=source,
+            target_locale=self.fr_locale,
+        )
+
+        self.assertEqual(translation.get_status_display(), "Up to date")
 
 
 class TestSaveTarget(TestCase):


### PR DESCRIPTION
Unlike COUNT, SUM will actually return NULL not 0 when there are no rows, so we need to coalesce to 0 to avoid such cases.

This issued caused both the progress and status values to be incorrect for translations. Since `0 != None` an empty page will have its translations marked as "waiting for translations."